### PR TITLE
Multiple interaction files & external events

### DIFF
--- a/heartbot/index.coffee
+++ b/heartbot/index.coffee
@@ -20,8 +20,8 @@ module.exports = (_config, robot) ->
   if config.events?.length
     config.events.forEach (externalEvents) ->
       eventPath = path.join hubotPath, externalEvents
-      eventName = externalEvents.replace /(.)+\//, ''
-      events[eventName.replace /\.coffee$/, ''] = require path.join hubotPath, externalEvents
+      eventFile = externalEvents.replace /(.)+\//, ''
+      events[eventFile.replace /\.coffee$/, ''] = require path.join hubotPath, externalEvents
   else
     robot.logger.warning 'No custom events defined.'
     return

--- a/heartbot/index.coffee
+++ b/heartbot/index.coffee
@@ -20,6 +20,15 @@ module.exports = (_config, robot) ->
     robot.logger.warning 'No heartbot interactions configured.'
     return
 
+  if config.eventsPath?.length
+    externalEventsPath = path.join hubotPath, config.eventsPath
+    for event in fs.readdirSync(externalEventsPath).sort()
+      events[event.replace /\.coffee$/, ''] = require path.join externalEventsPath, event
+  else
+    robot.logger.warning 'No external events path defined.'
+    return
+
+
   config.patterns.forEach (pattern) ->
     patternPath = path.join hubotPath, pattern
     try

--- a/heartbot/index.coffee
+++ b/heartbot/index.coffee
@@ -16,18 +16,19 @@ for event in fs.readdirSync(eventsPath).sort()
 
 module.exports = (_config, robot) ->
   config = _config
-  if not config.patterns?.length
-    robot.logger.warning 'No heartbot interactions configured.'
-    return
 
   if config.events?.length
-    externalEventsPath = path.join hubotPath, config.events
-    for event in fs.readdirSync(externalEventsPath).sort()
-      events[event.replace /\.coffee$/, ''] = require path.join externalEventsPath, event
+    config.events.forEach (externalEvents) ->
+      eventPath = path.join hubotPath, externalEvents
+      eventName = externalEvents.replace /(.)+\//, ''
+      events[eventName.replace /\.coffee$/, ''] = require path.join hubotPath, externalEvents
   else
     robot.logger.warning 'No custom events defined.'
     return
 
+  if not config.patterns?.length
+    robot.logger.warning 'No heartbot interactions configured.'
+    return
 
   config.patterns.forEach (pattern) ->
     patternPath = path.join hubotPath, pattern

--- a/heartbot/index.coffee
+++ b/heartbot/index.coffee
@@ -20,12 +20,12 @@ module.exports = (_config, robot) ->
     robot.logger.warning 'No heartbot interactions configured.'
     return
 
-  if config.eventsPath?.length
-    externalEventsPath = path.join hubotPath, config.eventsPath
+  if config.events?.length
+    externalEventsPath = path.join hubotPath, config.events
     for event in fs.readdirSync(externalEventsPath).sort()
       events[event.replace /\.coffee$/, ''] = require path.join externalEventsPath, event
   else
-    robot.logger.warning 'No external events path defined.'
+    robot.logger.warning 'No custom events defined.'
     return
 
 


### PR DESCRIPTION
As proposed in #2, this allow to have multiple interaction YAML files to provide a better and lighter patterns organization. This allow also to define external events to not edit the original dependency module.

Now, the `heartbot.config.yml` looks like : 

``` yml

---
probability: 1
patterns:
  - patterns/discussion.yml
  - patterns/weather.yml
  - patterns/gifs.yml
events:
  - events/something.coffee
```

And an interaction file (ex: `patterns/discussion.yml`) looks like : 

``` yml
interactions:

    - pattern:
        regex: >-
          (hi|hello|hey)(!|,)? ##heartbot##!?
      event: say
      message: Hi $user!
      probability: 1
```
